### PR TITLE
Parse YARD parameter docs with type

### DIFF
--- a/lib/puppet-lint/plugins/check_parameter_documentation.rb
+++ b/lib/puppet-lint/plugins/check_parameter_documentation.rb
@@ -9,7 +9,7 @@ PuppetLint.new_check(:parameter_documentation) do
         if [:COMMENT, :MLCOMMENT, :SLASH_COMMENT].include?(dtok.type)
           if dtok.value =~ /\A\s*\[\*([a-zA-Z0-9_]+)\*\]/ or
              dtok.value =~ /\A\s*\$([a-zA-Z0-9_]+):: +/ or
-             dtok.value =~ /\A\s*@param ([a-zA-Z0-9_]+) +/
+             dtok.value =~ /\A\s*@param (?:\[.+\] )?([a-zA-Z0-9_]+) +/
             doc_params << $1
           end
         else

--- a/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
+++ b/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
@@ -376,6 +376,44 @@ define foreman (
     end
   end
 
+  context 'class with all parameters documented (@param)' do
+    let(:code) do
+      <<-EOS
+      # Example class
+      #
+      # === Parameters:
+      #
+      # @param foo example
+      # @param [Integer] bar example
+      #
+      class example($foo, $bar) { }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
+  context 'define with all parameters documented (@param)' do
+    let(:code) do
+      <<-EOS
+      # Example define
+      #
+      # === Parameters:
+      #
+      # @param foo example
+      # @param [Integer] bar example
+      #
+      define example($foo, $bar) { }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'class without parameters' do
     let(:code) { 'class example { }' }
 


### PR DESCRIPTION
Support Puppet Strings YARD syntax with the type specified in square
brackets, used for Puppet 3 compatibility, e.g.

    # @param [String] first The first parameter for this class.

(https://github.com/puppetlabs/puppet-strings/blob/1.0.0/README.md#documenting-puppet-classes-and-defined-types)