### PR TITLE
Allow multiline Puppet Strings documentation of parameters.

### DIFF
--- a/lib/puppet-lint/plugins/check_parameter_documentation.rb
+++ b/lib/puppet-lint/plugins/check_parameter_documentation.rb
@@ -9,7 +9,7 @@ PuppetLint.new_check(:parameter_documentation) do
         if [:COMMENT, :MLCOMMENT, :SLASH_COMMENT].include?(dtok.type)
           if dtok.value =~ /\A\s*\[\*([a-zA-Z0-9_]+)\*\]/ or
              dtok.value =~ /\A\s*\$([a-zA-Z0-9_]+):: +/ or
-             dtok.value =~ /\A\s*@param (?:\[.+\] )?([a-zA-Z0-9_]+) +/
+             dtok.value =~ /\A\s*@param (?:\[.+\] )?([a-zA-Z0-9_]+)(?: +|$)/
             doc_params << $1
           end
         else

--- a/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
+++ b/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
@@ -385,8 +385,12 @@ define foreman (
       #
       # @param foo example
       # @param [Integer] bar example
+      # @param baz
+      #   example
+      # @param [Integer] qux
+      #   example
       #
-      class example($foo, $bar) { }
+      class example($foo, $bar, $baz, $qux) { }
       EOS
     end
 
@@ -404,8 +408,12 @@ define foreman (
       #
       # @param foo example
       # @param [Integer] bar example
+      # @param baz
+      #   example
+      # @param [Integer] qux
+      #   example
       #
-      define example($foo, $bar) { }
+      define example($foo, $bar, $baz, $qux) { }
       EOS
     end
 


### PR DESCRIPTION
The current regex for matching Puppet Strings parameter documentation only works if there's a trailing space after the parameter name, like this:
```
# @param foo example
```
I prefer to have the documentation of the parameter on the next line, though, like this:
```
# @param foo
#   example
```
This change modifies the regex to match both styles.