### PR TITLE
Add simplecov as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Gemfile.lock
 pkg/
 .ruby-*
+/coverage/

--- a/puppet-lint-param-docs.gemspec
+++ b/puppet-lint-param-docs.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
The puppet-lint spec helper requries simplecov and we include that helper.