### PR TITLE
Whitelist private APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,6 @@ helper to customise the lint rake task:
 This would disable the parameter_documentation check by default, but then
 defines a new rake task (which runs after `lint`) specifically for the files
 given in `config.pattern`.
+
+The [Puppet Strings](#puppet_strings) `@api private` directive can also be used
+to disable checks on that file.

--- a/lib/puppet-lint/plugins/check_parameter_documentation.rb
+++ b/lib/puppet-lint/plugins/check_parameter_documentation.rb
@@ -4,6 +4,7 @@ PuppetLint.new_check(:parameter_documentation) do
       next if idx[:param_tokens].nil?
 
       doc_params = []
+      is_private = false
       tokens[0..idx[:start]].reverse_each do |dtok|
         next if [:CLASS, :DEFINE, :NEWLINE, :WHITESPACE, :INDENT].include?(dtok.type)
         if [:COMMENT, :MLCOMMENT, :SLASH_COMMENT].include?(dtok.type)
@@ -12,10 +13,14 @@ PuppetLint.new_check(:parameter_documentation) do
              dtok.value =~ /\A\s*@param (?:\[.+\] )?([a-zA-Z0-9_]+)(?: +|$)/
             doc_params << $1
           end
+
+          is_private = true if dtok.value =~ /\A\s*@api +private\s*$/
         else
           break
         end
       end
+
+      next if is_private
 
       params = []
       e = idx[:param_tokens].each

--- a/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
+++ b/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
@@ -149,6 +149,27 @@ define foreman (
     end
   end
 
+  context 'private class missing documentation (@param bar) for a parameter' do
+    let(:code) do
+      <<-EOS.gsub(/^\s+/, '')
+      # Example class
+      #
+      # @api private
+      #
+      # @param bar example
+      class example($foo, $bar) { }
+      EOS
+    end
+
+    it 'should detect no single problems' do
+      expect(problems).to have(0).problems
+    end
+
+    it 'should not create a warning' do
+      expect(problems).not_to contain_info(class_msg % :foo)
+    end
+  end
+
   context 'define missing documentation (@param bar) for a parameter' do
     let(:code) do
       <<-EOS.gsub(/^\s+/, '')


### PR DESCRIPTION
Private APIs don't need to every parameter to be documented.