### PR TITLE
Only release on Ruby 2.6 Travis workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ deploy:
     secure: hyCFDUbXeBClJkMKd4/eOPzjj9n8VxxbTqPcN0QfqhRBWVDjwc//9vtjIPb1h3QyjRAbfs3ftZQAHlxYqA8dHxuhn0mCdtHqAY36NIlqlshQAptHxcXDBZnGU1P9lR/X7nsGOZOJKkjxYDs5rq8f5NgDZr6dWk71jD3hErm8nvE=
   gem: puppet-lint-param-docs
   on:
+    rvm: 2.6
     tags: true
     repo: voxpupuli/puppet-lint-param-docs


### PR DESCRIPTION
34fed76768bd3681b4b48c9bdd0dec57d7caf343 started to test on multiple Ruby versions. The side effect is that it tries to deploy on every version which causes the build to fail.