### PR TITLE
Use absolute parameter name in warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,29 @@ gem 'puppet-lint-param-docs'
 
 This plugin provides a new check to `puppet-lint`.
 
-### parameter_documentation
+### parameter\_documentation
 
 **--fix support: No**
 
 This check will raise a warning for any class or defined type parameters that
-don't have an RDoc description.
+don't have a description.
 
 ```
 WARNING: missing documentation for class parameter foo::bar
 WARNING: missing documentation for defined type parameter foo::baz
+```
+
+It will also raise warnings for parameters documented more than once.
+
+```
+WARNING Duplicate class parameter documentation for foo::bar on line 5
+WARNING Duplicate class parameter documentation for foo::bar on line 6
+```
+
+A warning will also be raised if you document a parameter that doesn't exist in the class or defined type.
+
+```
+WARNING No matching class parameter for documentation of foo::bar
 ```
 
 ### Documentation styles
@@ -39,36 +52,42 @@ The check will accept any of the following styles:
 
 Used by [Puppet Strings](https://github.com/puppetlabs/puppetlabs-strings).
 
-    # Example class
-    #
-    # @param foo example
-    define example($foo) { }
+```puppet
+# @summary Example class
+#
+# @param foo example
+define example($foo) { }
+```
 
 #### Puppet Doc style
 
-Used by the [puppet-doc](https://docs.puppetlabs.com/puppet/latest/reference/man/doc.html)
-command, generally deprecated in favour of Puppet Strings.
+Used by the [puppet-doc](https://puppet.com/docs/puppet/6.18/man/doc.html)
+command, deprecated in favour of Puppet Strings.
 
-    # Example class
-    #
-    # === Parameters:
-    #
-    # [*foo*] example
-    #
-    class example($foo) { }
+```puppet
+# Example class
+#
+# === Parameters:
+#
+# [*foo*] example
+#
+class example($foo) { }
+```
 
 #### Kafo rdoc style
 
 Used in [kafo](https://github.com/theforeman/kafo#documentation) following an
 rdoc style.
 
-    # Example class
-    #
-    # === Parameters:
-    #
-    # $foo:: example
-    #
-    class example($foo) { }
+```puppet
+# Example class
+#
+# === Parameters:
+#
+# $foo:: example
+#
+class example($foo) { }
+```
 
 ### Selective rake task
 
@@ -83,7 +102,7 @@ helper to customise the lint rake task:
       config.pattern = ['manifests/init.pp', 'manifests/other/**/*.pp']
     end
 
-This would disable the parameter_documentation check by default, but then
+This would disable the parameter\_documentation check by default, but then
 defines a new rake task (which runs after `lint`) specifically for the files
 given in `config.pattern`.
 

--- a/lib/puppet-lint/plugins/check_parameter_documentation.rb
+++ b/lib/puppet-lint/plugins/check_parameter_documentation.rb
@@ -29,7 +29,7 @@ PuppetLint.new_check(:parameter_documentation) do
       doc_params_duplicates.each do |parameter, tokens|
         tokens.each do |token|
            notify :warning, {
-             :message => "Duplicate #{type_str(idx)} parameter documentation for #{parameter}",
+             :message => "Duplicate #{type_str(idx)} parameter documentation for #{idx[:name_token].value}::#{parameter}",
              :line    => token.line,
              :column  => token.column + token.value.match(/\A\s*(@param\s*)?/)[0].length + 1 # `+ 1` is to account for length of the `#` COMMENT token.
            }
@@ -41,7 +41,7 @@ PuppetLint.new_check(:parameter_documentation) do
         next if params.find { |p| p.value == parameter }
 
         notify :warning, {
-          :message => "No matching #{type_str(idx)} parameter for documentation of #{parameter}",
+          :message => "No matching #{type_str(idx)} parameter for documentation of #{idx[:name_token].value}::#{parameter}",
           :line    => token.line,
           :column  => token.column + token.value.match(/\A\s*(@param\s*)?/)[0].length + 1
         }

--- a/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
+++ b/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
@@ -545,9 +545,13 @@ define foreman (
     end
   end
 
-  context 'class with parameters documented twice (@param)' do
-    let(:code) do
-      <<-EOS.gsub(/^\s+/, '')
+  describe 'Duplicated documentation' do
+    let(:class_msg) { 'Duplicate class parameter documentation for example::%s' }
+    let(:define_msg) { 'Duplicate defined type parameter documentation for example::%s' }
+
+    context 'class with parameters documented twice (@param)' do
+      let(:code) do
+        <<-EOS.gsub(/^\s+/, '')
       # @summary Example class
       #
       # @param bar
@@ -556,25 +560,52 @@ define foreman (
       # @param bar Duplicate/conflicting docs
       #
       class example($foo, $bar) { }
-    EOS
+        EOS
+      end
+
+      it 'should detect two problems' do
+        expect(problems).to have(2).problem
+      end
+
+      it 'should create a warning on line 3' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(3).in_column(10)
+      end
+
+      it 'should create a warning on line 6' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(6).in_column(10)
+      end
     end
 
-    it 'should detect two problems' do
-      expect(problems).to have(2).problem
+    context 'define with parameters documented twice (@param)' do
+      let(:code) do
+        <<-EOS.gsub(/^\s+/, '')
+      # @summary Example define
+      #
+      # @param bar
+      #   example
+      # @param foo example
+      # @param bar Duplicate/conflicting docs
+      #
+      define example($foo, $bar) { }
+        EOS
+      end
+
+      it 'should detect two problems' do
+        expect(problems).to have(2).problem
+      end
+
+      it 'should create a warning on line 3' do
+        expect(problems).to contain_warning(define_msg % :bar).on_line(3).in_column(10)
+      end
+
+      it 'should create a warning on line 6' do
+        expect(problems).to contain_warning(define_msg % :bar).on_line(6).in_column(10)
+      end
     end
 
-    it 'should create a warning on line 3' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(3).in_column(10)
-    end
-
-    it 'should create a warning on line 6' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(6).in_column(10)
-    end
-  end
-
-  context 'class with parameters documented 3 times (@param)' do
-    let(:code) do
-      <<-EOS.gsub(/^\s+/, '')
+    context 'class with parameters documented 3 times (@param)' do
+      let(:code) do
+        <<-EOS.gsub(/^\s+/, '')
       # @summary Example class
       #
       # @param bar
@@ -586,29 +617,29 @@ define foreman (
       #   example
       #
       class example($foo, $bar) { }
-    EOS
+        EOS
+      end
+
+      it 'should detect three problems' do
+        expect(problems).to have(3).problem
+      end
+
+      it 'should create a warning on line 3' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(3).in_column(10)
+      end
+
+      it 'should create a warning on line 6' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(6).in_column(10)
+      end
+
+      it 'should create a warning on line 8' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(8).in_column(10)
+      end
     end
 
-    it 'should detect three problems' do
-      expect(problems).to have(3).problem
-    end
-
-    it 'should create a warning on line 3' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(3).in_column(10)
-    end
-
-    it 'should create a warning on line 6' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(6).in_column(10)
-    end
-
-    it 'should create a warning on line 8' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(8).in_column(10)
-    end
-  end
-
-  context 'private class with parameters documented twice (@param)' do
-    let(:code) do
-      <<-EOS.gsub(/^\s+/, '')
+    context 'private class with parameters documented twice (@param)' do
+      let(:code) do
+        <<-EOS.gsub(/^\s+/, '')
       # @summary Example class
       #
       # @param bar docs
@@ -616,25 +647,25 @@ define foreman (
       #
       # @api private
       class example($bar) { }
-    EOS
+        EOS
+      end
+
+      it 'should detect two problems' do
+        expect(problems).to have(2).problem
+      end
+
+      it 'should create a warning on line 3' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(3).in_column(10)
+      end
+
+      it 'should create a warning on line 4' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(4).in_column(10)
+      end
     end
 
-    it 'should detect two problems' do
-      expect(problems).to have(2).problem
-    end
-
-    it 'should create a warning on line 3' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(3).in_column(10)
-    end
-
-    it 'should create a warning on line 4' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(4).in_column(10)
-    end
-  end
-
-  context 'class with parameters documented twice ([*bar*])' do
-    let(:code) do
-      <<-EOS.gsub(/^\s+/, '')
+    context 'class with parameters documented twice ([*bar*])' do
+      let(:code) do
+        <<-EOS.gsub(/^\s+/, '')
       # @summary Example class
       #
       # @param bar
@@ -643,19 +674,20 @@ define foreman (
       # [*bar*] Duplicate/conflicting docs
       #
       class example($foo, $bar) { }
-    EOS
-    end
+        EOS
+      end
 
-    it 'should detect two problems' do
-      expect(problems).to have(2).problem
-    end
+      it 'should detect two problems' do
+        expect(problems).to have(2).problem
+      end
 
-    it 'should create a warning on line 3' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(3).in_column(10)
-    end
+      it 'should create a warning on line 3' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(3).in_column(10)
+      end
 
-    it 'should create a warning on line 6' do
-      expect(problems).to contain_warning('Duplicate class parameter documentation for bar').on_line(6).in_column(3)
+      it 'should create a warning on line 6' do
+        expect(problems).to contain_warning(class_msg % :bar).on_line(6).in_column(3)
+      end
     end
   end
 
@@ -666,7 +698,7 @@ define foreman (
       #
       # @param foo
       class example { }
-    EOS
+      EOS
     end
 
     it 'should detect a single problem' do
@@ -674,7 +706,7 @@ define foreman (
     end
 
     it 'should create a warning on line 3' do
-      expect(problems).to contain_warning('No matching class parameter for documentation of foo').on_line(3).in_column(10)
+      expect(problems).to contain_warning('No matching class parameter for documentation of example::foo').on_line(3).in_column(10)
     end
   end
 
@@ -688,7 +720,7 @@ define foreman (
       #
       # @api private
       class example { }
-    EOS
+      EOS
     end
 
     it 'should detect a single problem' do
@@ -696,7 +728,7 @@ define foreman (
     end
 
     it 'should create a warning on line 3' do
-      expect(problems).to contain_warning('No matching class parameter for documentation of foo').on_line(3).in_column(10)
+      expect(problems).to contain_warning('No matching class parameter for documentation of example::foo').on_line(3).in_column(10)
     end
   end
 
@@ -711,7 +743,7 @@ define foreman (
       #
       # @api private
       define example::example(String[1] $bar) { }
-    EOS
+      EOS
     end
 
     it 'should detect a single problem' do
@@ -719,7 +751,7 @@ define foreman (
     end
 
     it 'should create a warning on line 4' do
-      expect(problems).to contain_warning('No matching defined type parameter for documentation of foo').on_line(4).in_column(10)
+      expect(problems).to contain_warning('No matching defined type parameter for documentation of example::example::foo').on_line(4).in_column(10)
     end
   end
 end


### PR DESCRIPTION
Makes the new warnings consistent with the `missing documentation`
warnings.