### PR TITLE
GitHub Actions: Set 0600 perms to gem credentials file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,6 @@ jobs:
       - name: Setup GitHub packages access
         run: |
           echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
+          chmod 0600 /home/runner/.gem/credentials
       - name: Publish gem to GitHub packages
         run: gem push --key github --host https://rubygems.pkg.github.com/voxpupuli/puppet-lint-param-docs *.gem


### PR DESCRIPTION
The GitHub action manipulates the file and probably because of a strange
umask, the permissions are 0644. Without this fix we get the following
error message:
```
Run gem push --key github --host https://rubygems.pkg.github.com/voxpupuli/puppet-lint-param-docs *.gem
  gem push --key github --host https://rubygems.pkg.github.com/voxpupuli/puppet-lint-param-docs *.gem
  shell: /usr/bin/bash -e {0}
ERROR:  Your gem push credentials file located at:

	/home/runner/.gem/credentials

has file permissions of 0644 but 0600 is required.

To fix this error run:

	chmod 0600 /home/runner/.gem/credentials
```