### PR TITLE
GitHub Actions: Fix pushing the gem to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
           echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
           chmod 0600 /home/runner/.gem/credentials
       - name: Publish gem to GitHub packages
-        run: gem push --key github --host https://rubygems.pkg.github.com/voxpupuli/ *.gem
+        run: gem push --key github --host https://rubygems.pkg.github.com/voxpupuli *.gem


### PR DESCRIPTION
A trailing slash in the host uri breaks the submission without
indicating the reason.

Tested manualy against a fork of the repository.